### PR TITLE
feat: Adding AnyURLSession support to LaunchDarkly

### DIFF
--- a/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
+++ b/LaunchDarkly/LaunchDarkly/Networking/DarklyService.swift
@@ -2,7 +2,12 @@ import Foundation
 import LDSwiftEventSource
 
 #if os(Linux) || os(Windows)
-import FoundationNetworking
+import class FoundationNetworking.URLResponse
+import class FoundationNetworking.HTTPURLResponse
+import struct FoundationNetworking.URLRequest
+
+import class FoundationNetworking.URLSessionConfiguration
+import AnyURLSession
 #endif
 
 typealias ServiceResponse = (data: Data?, urlResponse: URLResponse?, error: Error?)
@@ -115,7 +120,7 @@ final class DarklyService: DarklyServiceProvider {
         }
 
         self.session.dataTask(with: request) { [weak self] data, response, error in
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 self?.processEtag(from: (data, response, error))
                 completion?((data, response, error))
             }

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .exact("9.1.0")),
         .package(url: "https://github.com/Quick/Quick.git", .exact("7.3.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .exact("13.0.0")),
-        .package(name: "LDSwiftEventSource", url: "https://github.com/LaunchDarkly/swift-eventsource.git", .revisionItem("ac5f18c")),
+        .package(name: "LDSwiftEventSource", url: "https://github.com/thebrowsercompany/swift-eventsource.git", .branchItem("main-bcny")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This updates the LaunchDarkly SDK to use the forked version of `swift-eventsource` which also brings in the `AnyURLSession` library.

We've adjusted the code in this SDK to allow for the usage of AnyURLSession which gives us a pluggable API surface to substitute Chromium's networking stack into (if we so desire) at a later date.