### PR TITLE
Lock Swift package dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
+      - name: Select Windows SDK 10.0.22621.0
+        uses: compnerd/gha-setup-vsdevenv@452f99effa381b81c025ccfbdccaca509bff1b29
+        with:
+          winsdk: 10.0.22621.0
       - name: Install Swift
         uses: compnerd/gha-setup-swift@main
         with:
           branch: swift-5.9-release
           tag: 5.9-RELEASE
-      - name: Select Windows SDK 10.0.22621.0
-        uses: compnerd/gha-setup-vsdevenv@452f99effa381b81c025ccfbdccaca509bff1b29
-        with:
-          winsdk: 10.0.22621.0
       - name: Build Windows
         run: swift test --disable-automatic-resolution
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           branch: swift-5.9-release
           tag: 5.9-RELEASE
       - name: Build Windows
-        run: swift test
+        run: swift test --disable-automatic-resolution
 
   library-darwin:
     name: macOS - Swift 5.9 - SPM
@@ -26,4 +26,4 @@ jobs:
       - name: Select Xcode 15.0.1
         run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
       - name: Run tests
-        run: swift test
+        run: swift test --disable-automatic-resolution

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           branch: swift-5.9-release
           tag: 5.9-RELEASE
+      - name: Select Windows SDK 10.0.22621.0
+        uses: compnerd/gha-setup-vsdevenv@452f99effa381b81c025ccfbdccaca509bff1b29
+        with:
+          winsdk: 10.0.22621.0
       - name: Build Windows
         run: swift test --disable-automatic-resolution
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   library-windows:
     name: Windows - Swift 5.9 - SPM
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
       - name: Install Swift
@@ -20,7 +20,7 @@ jobs:
 
   library-darwin:
     name: macOS - Swift 5.9 - SPM
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode 15.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ xcuserdata
 /Carthage/Checkouts
 **/.swiftpm
 **/Package.resolved
+!/Package.resolved
 /LaunchDarkly.xcworkspace/xcshareddata/swiftpm/Package.resolved
 /LaunchDarkly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,70 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-anyurlsession",
+        "repositoryURL": "https://github.com/thebrowsercompany/AnyURLSession",
+        "state": {
+          "branch": "main",
+          "revision": "5d4e0109a868bd118acfb25910fb72aed3f0fa93",
+          "version": null
+        }
+      },
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "07b2ba21d361c223e25e3c1e924288742923f08c",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "d616f15123bfb36db1b1075153f73cf40605b39d",
+          "version": "13.0.0"
+        }
+      },
+      {
+        "package": "OHHTTPStubs",
+        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
+        "state": {
+          "branch": null,
+          "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+          "version": "9.1.0"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "ef9aaf3f634b3a1ab6f54f1173fe2400b36e7cb8",
+          "version": "7.3.0"
+        }
+      },
+      {
+        "package": "LDSwiftEventSource",
+        "repositoryURL": "https://github.com/thebrowsercompany/swift-eventsource.git",
+        "state": {
+          "branch": "main-bcny",
+          "revision": "1fc81e48ba3ae0a3656888ea582e46b602bba76d",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
This PR locks the Swift package graph and pins compatible CI images so Windows and macOS builds can verify it without silently changing dependencies.

The SDK depends on moving branches for swift-eventsource and AnyURLSession. `Package.resolved` now pins those branches, along with every versioned dependency, to exact commits. ContractTests is not part of the current CI workflow and remains unchanged.

# Changes

- Commit the root Swift package lockfile.
- Disable automatic dependency resolution in both CI jobs so a stale lockfile fails the build.
- Pin Windows to the VS 2022 runner and Windows SDK 10.0.22621 required by Swift 5.9. Move the retired macOS 13 job to macOS 14 while retaining Xcode 15.0.1.

# Testing

- Resolved the package strictly from the lockfile.
- Ran all 582 SDK tests successfully with automatic resolution disabled.
